### PR TITLE
Small tweaks: Semi-transparent floor, fix appname override

### DIFF
--- a/Assets/Materials/GroundMat.mat
+++ b/Assets/Materials/GroundMat.mat
@@ -4,16 +4,18 @@
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   m_Name: GroundMat
   m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
-  m_ShaderKeywords: _EMISSION
+  m_ShaderKeywords: _ALPHAPREMULTIPLY_ON _EMISSION
   m_LightmapFlags: 1
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
   disabledShaderPasses: []
   m_SavedProperties:
     serializedVersion: 3
@@ -58,19 +60,19 @@ Material:
     - _BumpScale: 1
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
-    - _DstBlend: 0
+    - _DstBlend: 10
     - _GlossMapScale: 1
     - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
-    - _Mode: 0
+    - _Mode: 3
     - _OcclusionStrength: 1
     - _Parallax: 0.02
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1
     - _UVSec: 0
-    - _ZWrite: 1
+    - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 0.2509804, g: 0.2627451, b: 0.29803923, a: 1}
+    - _Color: {r: 0.25098035, g: 0.26274505, b: 0.29803917, a: 0.6156863}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Scripts/AppProcessor.cs
+++ b/Assets/Scripts/AppProcessor.cs
@@ -280,7 +280,7 @@ namespace QuestAppLauncher
                     {
                         PackageName = apps[entry.Key].PackageName,
                         Index = apps[entry.Key].Index,
-                        AppName = appName,
+                        AppName = !String.IsNullOrWhiteSpace(appName) ? appName : apps[entry.Key].AppName,
                         AutoTabName = autoTabName ?? apps[entry.Key].AutoTabName,
                         Tab1Name = tab1 ?? apps[entry.Key].Tab1Name,
                         Tab2Name = tab2 ?? apps[entry.Key].Tab2Name,


### PR DESCRIPTION
Small tweaks:
- Made floor semi-transparent (this was lost somehow)
- Fixed appnames override to not set name to empty string if only category is over-ridden.